### PR TITLE
Removed sanitize option consideration for translation

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2002,8 +2002,9 @@ class Html(_String):
         # called by _setup_attrs(), working together with _String._setup_attrs()
         attrs = super()._get_attrs(model_class, name)
         # Translated sanitized html fields must use html_translate or a callable.
-        if attrs.get('translate') is True and attrs.get('sanitize', True):
-            attrs['translate'] = html_translate
+        # if attrs.get('translate') is True and attrs.get('sanitize', True):
+        #     attrs['translate'] = html_translate
+        # Commented above code to ignore sanitize attr, we will consider it as False always.
         return attrs
 
     @property


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR: html_translate callback was used for sanitize = true

Desired behavior after PR is merged: All html field are translated considering sanitize = False




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
